### PR TITLE
fix repo name

### DIFF
--- a/scala-runner
+++ b/scala-runner
@@ -43,7 +43,7 @@ getScalaHead() {
 }
 getScalaNext() {
   vlog "[getScalaNext] arg = '$1'"
-  curl -Ls "https://raw.github.com/scala/community-builds/$1/nightly.properties" \
+  curl -Ls "https://raw.github.com/scala/community-build/$1/nightly.properties" \
     | sed -n 's/nightly=\(.*\)/\1/p'
 }
 setScalaVersion() {


### PR DESCRIPTION
it doesn't matter, it redirects, but we might as well have the current
right name